### PR TITLE
Use same relative path for SettingsFilename as TestSuiteFilename

### DIFF
--- a/NBi.NUnit.Runtime/TestSuite.cs
+++ b/NBi.NUnit.Runtime/TestSuite.cs
@@ -266,7 +266,7 @@ namespace NBi.NUnit.Runtime
             EnableAutoCategories = config.EnableAutoCategories;
             EnableGroupAsCategory = config.EnableGroupAsCategory;
             AllowDtdProcessing = config.AllowDtdProcessing;
-            SettingsFilename = config.SettingsFilename;
+            SettingsFilename = AppDomain.CurrentDomain.SetupInformation.ApplicationBase + config.SettingsFilename;
             Configuration = new TestConfiguration(config.FailureReportProfile);
         }
 

--- a/NBi.UI.Genbi/NBi.UI.Genbi.csproj
+++ b/NBi.UI.Genbi/NBi.UI.Genbi.csproj
@@ -452,7 +452,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy /Q "$(SolutionDir)NBi.Core\$(OutDir)Microsoft.AnalysisServices.AdomdClient.dll" "$(TargetDir)"</PostBuildEvent>
+    <PostBuildEvent>xcopy /Q /Y "$(SolutionDir)NBi.Core\$(OutDir)Microsoft.AnalysisServices.AdomdClient.dll" "$(TargetDir)"</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Fixed that the relative location towards the nbits and nbiset file are the same
<nbi testSuite="TestCases.nbits" settings="Settings.nbiset" />
