### PR TITLE
Csv null value support

### DIFF
--- a/NBi.Core/CsvReader.cs
+++ b/NBi.Core/CsvReader.cs
@@ -171,6 +171,9 @@ namespace NBi.Core
             if (string.IsNullOrEmpty(item))
                 return string.Empty;
 
+            if (item == "(null)")
+                return null;
+
             if (item.Length == 1)
                 return item;
 

--- a/NBi.Testing/Unit/Core/CsvReaderTest.cs
+++ b/NBi.Testing/Unit/Core/CsvReaderTest.cs
@@ -14,6 +14,9 @@ namespace NBi.Testing.Unit.Core
     {
         [Test]
         [TestCase(null, "")]
+        [TestCase("(null)", null)] //Parse (null) to a real null value
+        [TestCase("\"(null)\"", "(null)")] //Explicitly quoted (null) should be (null)
+        [TestCase("null", "null")]
         [TestCase("", "")]
         [TestCase("a", "a")]
         [TestCase("\"", "\"")]


### PR DESCRIPTION
We use a lot of CSV files to validate MDX query output. For validation we needed NULL support in CSV files (instead of string.empty).
Added this using the (null) convention
