### PR TITLE
Remove requirement for [schema_owner] = 'dbo'

### DIFF
--- a/NBi.Core/Structure/Relational/Builders/SchemaDiscoveryCommandBuilder.cs
+++ b/NBi.Core/Structure/Relational/Builders/SchemaDiscoveryCommandBuilder.cs
@@ -11,7 +11,7 @@ namespace NBi.Core.Structure.Relational.Builders
     {
         protected override string BasicCommandText
         {
-            get { return base.BasicCommandText + " and [schema_owner]='dbo'"; }
+            get { return base.BasicCommandText; }
         }
 
         public SchemaDiscoveryCommandBuilder()

--- a/NBi.Testing/Integration/Core/Structure/Relational/RelationalStructureDiscoveryFactoryTest.cs
+++ b/NBi.Testing/Integration/Core/Structure/Relational/RelationalStructureDiscoveryFactoryTest.cs
@@ -24,7 +24,7 @@ namespace NBi.Testing.Integration.Core.Structure.Relational
 
             var structs = cmd.Execute();
 
-            Assert.That(structs.Count(), Is.EqualTo(6 + 2 + 2));//6 standards + Northwind + Olympics + tSQLt + SQLCop
+            Assert.That(structs.Count(), Is.EqualTo(24)); //All available schemas
         }
 
         [Test]


### PR DESCRIPTION
If schema_owner differed from 'dbo', schema existence tests would fail.
