### PR TITLE
SaveSuiteAction serialize CSV profile properties incorrectly (#612)

### DIFF
--- a/NBi.Testing.GenbiL/Action/Suite/SaveSuiteActionTest.cs
+++ b/NBi.Testing.GenbiL/Action/Suite/SaveSuiteActionTest.cs
@@ -1,0 +1,76 @@
+﻿using NBi.GenbiL.Action.Suite;
+using NBi.GenbiL.Stateful;
+using NBi.Xml;
+using NUnit.Framework;
+using System;
+using System.IO;
+
+namespace NBi.Testing.GenbiL.Action.Suite
+{
+    [TestFixture]
+    public class SaveSuiteActionTest
+    {
+        protected TestSuiteXml DeserializeFile(string filename)
+        {
+            // Declare an object variable of the type to be deserialized.
+            var manager = new XmlManager();
+
+            // A Stream is needed to read the XML document.
+            using (Stream stream = new FileStream(filename, FileMode.Open))
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                manager.Read(reader);
+            }
+            manager.ApplyDefaultSettings();
+            return manager.TestSuite;
+        }
+
+        [Test]
+        [TestCase("(empty)", "(null)", ';', "\r\n", '"', false)]    // All defaults
+        [TestCase("(empty)", "(null)", ';', "\r\n", '"', true)]     // All defaults except FirstRowHeader
+        [TestCase("#", "(null)", ';', "\r\n", '"', true)]           // All defaults except EmptyCell and FirstRowHeader
+        [TestCase("(empty)", "#", ';', "\r\n", '"', true)]          // All defaults except MissingCell and FirstRowHeader
+        [TestCase("(empty)", "(null)", '#', "\r\n", '"', true)]     // All defaults except FieldSeparator and FirstRowHeader
+        [TestCase("(empty)", "(null)", ';', "#", '"', true)]        // All defaults except RecordSeparator and FirstRowHeader
+        [TestCase("(empty)", "(null)", ';', "\r\n", '#', true)]     // All defaults except TextQualifier and FirstRowHeader
+
+        [TestCase("#", "(null)", ';', "\r\n", '"', false)]           // All defaults except EmptyCell
+        [TestCase("#", "(null)", '|', "\r\n", '"', false)]           // All defaults except EmptyCell and FieldSeparator
+
+        [TestCase("(empty)", "#", ';', "\r\n", '"', false)]          // All defaults except MissingCell
+        [TestCase("(empty)", "#", '|', "\r\n", '"', false)]          // All defaults except MissingCell and FieldSeparator
+        public void Execute_CsvProfile_PropertiesSerialized(string emptyCell, string missingCell, char fieldSeparator, string recordSeparator, char textQualifier, bool firstRowHeader)
+        {
+            string filepath = Path.Combine(Path.GetTempPath(), $"Execute_CsvProfile_Saved_{ Guid.NewGuid() }.nbits");
+
+            if (File.Exists(filepath))
+            {
+                File.Delete(filepath);
+            }
+
+            var state = new GenerationState();
+            state.Settings.CsvProfile.EmptyCell = emptyCell;
+            state.Settings.CsvProfile.MissingCell = missingCell;
+            state.Settings.CsvProfile.FieldSeparator = fieldSeparator;
+            state.Settings.CsvProfile.RecordSeparator = recordSeparator;
+            state.Settings.CsvProfile.TextQualifier = textQualifier;
+            state.Settings.CsvProfile.FirstRowHeader = firstRowHeader;
+
+            var saveAction = new SaveSuiteAction(filepath);
+            saveAction.Execute(state);
+
+            var fileContent = DeserializeFile(filepath);
+            Assert.That(fileContent.Settings.CsvProfile.EmptyCell, Is.EqualTo(emptyCell));
+            Assert.That(fileContent.Settings.CsvProfile.MissingCell, Is.EqualTo(missingCell));
+            Assert.That(fileContent.Settings.CsvProfile.FieldSeparator, Is.EqualTo(fieldSeparator));
+            Assert.That(fileContent.Settings.CsvProfile.RecordSeparator, Is.EqualTo(recordSeparator));
+            Assert.That(fileContent.Settings.CsvProfile.TextQualifier, Is.EqualTo(textQualifier));
+            Assert.That(fileContent.Settings.CsvProfile.FirstRowHeader, Is.EqualTo(firstRowHeader));
+
+            if (File.Exists(filepath))
+            {
+                File.Delete(filepath);
+            }
+        }
+    }
+}

--- a/NBi.Testing.GenbiL/NBi.Testing.GenbiL.csproj
+++ b/NBi.Testing.GenbiL/NBi.Testing.GenbiL.csproj
@@ -85,6 +85,7 @@
     <Compile Include="Action\Setting\DefaultActionTest.cs" />
     <Compile Include="Action\Suite\GenerateTestGroupBySuiteActionTest.cs" />
     <Compile Include="Action\Suite\GenerateTestSuiteActionTest.cs" />
+    <Compile Include="Action\Suite\SaveSuiteActionTest.cs" />
     <Compile Include="Action\Template\AddEmbeddedTemplateActionTest.cs" />
     <Compile Include="Action\Variable\IncludeVariableActionTest.cs" />
     <Compile Include="Parser\CaseParserTest.cs" />

--- a/NBi.Xml/Settings/SettingsXml.cs
+++ b/NBi.Xml/Settings/SettingsXml.cs
@@ -31,7 +31,10 @@ namespace NBi.Xml.Settings
             var value = 
                 CsvProfile.InternalFieldSeparator != GetDefaultValue<string>(x => x.InternalFieldSeparator)
                 || CsvProfile.InternalRecordSeparator != GetDefaultValue<string>(x => x.InternalRecordSeparator)
-                || CsvProfile.InternalTextQualifier != GetDefaultValue<string>(x => x.InternalTextQualifier);
+                || CsvProfile.InternalTextQualifier != GetDefaultValue<string>(x => x.InternalTextQualifier)
+                || CsvProfile.InternalEmptyCell != GetDefaultValue<string>(x => x.InternalEmptyCell)
+                || CsvProfile.InternalMissingCell != GetDefaultValue<string>(x => x.InternalMissingCell)
+                || CsvProfile.InternalFirstRowHeader != GetDefaultValue<bool>(x => x.InternalFirstRowHeader);
 
             return value;
         }


### PR DESCRIPTION
EmptyCell, MissingCell and FirstRowHeader are included in NBi.Xml.Settings.SettingsXml.ShouldSerializeCsvProfile(). Test cases are included. 