### PR TITLE
Read environment variables from process rather than user scope

### DIFF
--- a/NBi.Core/Scalar/Resolver/EnvironmentScalarResolver.cs
+++ b/NBi.Core/Scalar/Resolver/EnvironmentScalarResolver.cs
@@ -18,7 +18,7 @@ namespace NBi.Core.Scalar.Resolver
 
         public T Execute()
         {
-            var value = Environment.GetEnvironmentVariable(args.Name, EnvironmentVariableTarget.User);
+            var value = Environment.GetEnvironmentVariable(args.Name);
             return (T)Convert.ChangeType(value, typeof(T));
         }
 

--- a/NBi.Core/Scalar/Resolver/EnvironmentScalarResolver.cs
+++ b/NBi.Core/Scalar/Resolver/EnvironmentScalarResolver.cs
@@ -18,7 +18,9 @@ namespace NBi.Core.Scalar.Resolver
 
         public T Execute()
         {
-            var value = Environment.GetEnvironmentVariable(args.Name);
+            var value = Environment.GetEnvironmentVariable(args.Name, EnvironmentVariableTarget.Process)
+                        ?? Environment.GetEnvironmentVariable(args.Name, EnvironmentVariableTarget.User);
+
             return (T)Convert.ChangeType(value, typeof(T));
         }
 

--- a/NBi.Testing.Core/Scalar/Resolver/EnvironmentScalarResolverTest.cs
+++ b/NBi.Testing.Core/Scalar/Resolver/EnvironmentScalarResolverTest.cs
@@ -11,14 +11,14 @@ namespace NBi.Testing.Core.Scalar.Resolver
 {
     public class EnvironmentScalarResolverTest
     {
-        [SetUp]
+        [OneTimeSetUp]
         public void CreateEnvironmentVariable()
         {
             Environment.SetEnvironmentVariable("NBiTestingProcess", "the_value_process", EnvironmentVariableTarget.Process);
             Environment.SetEnvironmentVariable("NBiTestingUser", "the_value_user", EnvironmentVariableTarget.User);
         }
 
-        [TearDown]
+        [OneTimeTearDown]
         public void DeleteEnvironmentVariable()
         {
             Environment.SetEnvironmentVariable("NBiTestingProcess", null, EnvironmentVariableTarget.Process);

--- a/NBi.Testing.Core/Scalar/Resolver/EnvironmentScalarResolverTest.cs
+++ b/NBi.Testing.Core/Scalar/Resolver/EnvironmentScalarResolverTest.cs
@@ -12,9 +12,9 @@ namespace NBi.Testing.Core.Scalar.Resolver
     public class EnvironmentScalarResolverTest
     {
         [SetUp]
-        public void CreateEnvironmentVariable() => Environment.SetEnvironmentVariable("NBiTesting", "the_value", EnvironmentVariableTarget.User);
+        public void CreateEnvironmentVariable() => Environment.SetEnvironmentVariable("NBiTesting", "the_value");
         [TearDown]
-        public void DeleteEnvironmentVariable() => Environment.SetEnvironmentVariable("NBiTesting", null, EnvironmentVariableTarget.User);
+        public void DeleteEnvironmentVariable() => Environment.SetEnvironmentVariable("NBiTesting", null);
 
         [Test]
         public void Instantiate_GetValueObject_CorrectRead()

--- a/NBi.Testing.Core/Scalar/Resolver/EnvironmentScalarResolverTest.cs
+++ b/NBi.Testing.Core/Scalar/Resolver/EnvironmentScalarResolverTest.cs
@@ -14,10 +14,21 @@ namespace NBi.Testing.Core.Scalar.Resolver
         [SetUp]
         public void CreateEnvironmentVariable() => Environment.SetEnvironmentVariable("NBiTesting", "the_value");
         [TearDown]
-        public void DeleteEnvironmentVariable() => Environment.SetEnvironmentVariable("NBiTesting", null);
+        public void DeleteEnvironmentVariable() => Environment.SetEnvironmentVariable("NBiTestingUser", null, EnvironmentVariableTarget.User);
 
         [Test]
-        public void Instantiate_GetValueObject_CorrectRead()
+        public void Instantiate_GetValueObject_CorrectReadUser()
+        {
+            var args = new EnvironmentScalarResolverArgs("NBiTestingUser");
+            var resolver = new EnvironmentScalarResolver<string>(args);
+
+            var output = resolver.Execute();
+
+            Assert.That(output, Is.EqualTo("the_valueUser"));
+        }
+
+        [Test]
+        public void Instantiate_GetValueObject_CorrectReadProcess()
         {
             var args = new EnvironmentScalarResolverArgs("NBiTesting");
             var resolver = new EnvironmentScalarResolver<string>(args);

--- a/NBi.Testing.Core/Scalar/Resolver/EnvironmentScalarResolverTest.cs
+++ b/NBi.Testing.Core/Scalar/Resolver/EnvironmentScalarResolverTest.cs
@@ -12,30 +12,50 @@ namespace NBi.Testing.Core.Scalar.Resolver
     public class EnvironmentScalarResolverTest
     {
         [SetUp]
-        public void CreateEnvironmentVariable() => Environment.SetEnvironmentVariable("NBiTesting", "the_value");
+        public void CreateEnvironmentVariable()
+        {
+            Environment.SetEnvironmentVariable("NBiTestingProcess", "the_value_process", EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("NBiTestingUser", "the_value_user", EnvironmentVariableTarget.User);
+        }
+
         [TearDown]
-        public void DeleteEnvironmentVariable() => Environment.SetEnvironmentVariable("NBiTestingUser", null, EnvironmentVariableTarget.User);
+        public void DeleteEnvironmentVariable()
+        {
+            Environment.SetEnvironmentVariable("NBiTestingProcess", null, EnvironmentVariableTarget.Process);
+            Environment.SetEnvironmentVariable("NBiTestingUser", null, EnvironmentVariableTarget.User);
+        }
 
         [Test]
-        public void Instantiate_GetValueObject_CorrectReadUser()
+        public void Execute_EnvVarUser_CorrectRead()
         {
             var args = new EnvironmentScalarResolverArgs("NBiTestingUser");
             var resolver = new EnvironmentScalarResolver<string>(args);
 
             var output = resolver.Execute();
 
-            Assert.That(output, Is.EqualTo("the_valueUser"));
+            Assert.That(output, Is.EqualTo("the_value_user"));
         }
 
         [Test]
-        public void Instantiate_GetValueObject_CorrectReadProcess()
+        public void Execute_EnvVarProcess_CorrectRead()
         {
-            var args = new EnvironmentScalarResolverArgs("NBiTesting");
+            var args = new EnvironmentScalarResolverArgs("NBiTestingProcess");
             var resolver = new EnvironmentScalarResolver<string>(args);
 
             var output = resolver.Execute();
 
-            Assert.That(output, Is.EqualTo("the_value"));
+            Assert.That(output, Is.EqualTo("the_value_process"));
+        }
+
+        [Test]
+        public void Execute_EnvVarMissing_CorrectRead()
+        {
+            var args = new EnvironmentScalarResolverArgs("NBiTestingMissing");
+            var resolver = new EnvironmentScalarResolver<string>(args);
+
+            var output = resolver.Execute();
+
+            Assert.That(output, Is.Null);
         }
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ after_build:
 test_script:
 - cmd: >-
     setx NBiTestingUser "the_valueUser"
+    
     nunit3-console NBi.Testing.Core\bin\debug\NBi.Testing.Core.dll NBi.Testing.Framework\bin\debug\NBi.Testing.Framework.dll NBi.Testing.GenbiL\bin\debug\NBi.Testing.GenbiL.dll NBi.Testing.Xml\bin\debug\NBi.Testing.Xml.dll  --where "cat!=Acceptance and cat!=Olap and cat!=Etl and cat!=WindowsService and cat!=ReportServerDB and cat!=LocalSQL" --result=myresults.xml;format=AppVeyor
     
     nunit-console-x86 NBi.Testing\bin\debug\NBi.Testing.dll /exclude:Olap,Etl,WindowsService,ReportServerDB,LocalSQL

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,12 +20,11 @@ after_build:
 
     .\.packages\package-NBi.ps1 $nuget_version
 test_script:
-- ps: |-
-    [System.Environment]::SetEnvironmentVariable("NBiTestingUser", "the_valueUser", "USER")
-- cmd: |-
+- cmd: >-
     nunit3-console NBi.Testing.Core\bin\debug\NBi.Testing.Core.dll NBi.Testing.Framework\bin\debug\NBi.Testing.Framework.dll NBi.Testing.GenbiL\bin\debug\NBi.Testing.GenbiL.dll NBi.Testing.Xml\bin\debug\NBi.Testing.Xml.dll  --where "cat!=Acceptance and cat!=Olap and cat!=Etl and cat!=WindowsService and cat!=ReportServerDB and cat!=LocalSQL" --result=myresults.xml;format=AppVeyor
+    
     nunit-console-x86 NBi.Testing\bin\debug\NBi.Testing.dll /exclude:Olap,Etl,WindowsService,ReportServerDB,LocalSQL
-
+    
 artifacts:
 - path: NBi.NUnit.Runtime\bin\Debug
   name: Framework

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,6 @@ after_build:
 
     .\.packages\package-NBi.ps1 $nuget_version
 test_script:
-- cmd: setx NBiTestingUser "the_value_user"
-- cmd: RefreshEnv.cmd
 - cmd: >-
     nunit3-console NBi.Testing.Core\bin\debug\NBi.Testing.Core.dll NBi.Testing.Framework\bin\debug\NBi.Testing.Framework.dll NBi.Testing.GenbiL\bin\debug\NBi.Testing.GenbiL.dll NBi.Testing.Xml\bin\debug\NBi.Testing.Xml.dll  --where "cat!=Acceptance and cat!=Olap and cat!=Etl and cat!=WindowsService and cat!=ReportServerDB and cat!=LocalSQL" --result=myresults.xml;format=AppVeyor
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,9 @@ after_build:
 
     .\.packages\package-NBi.ps1 $nuget_version
 test_script:
+- ps: |-
+    [System.Environment]::SetEnvironmentVariable("NBiTestingUser", "the_valueUser", "USER")
 - cmd: |-
-    setx NBiTestingUser "the_valueUser"
     nunit3-console NBi.Testing.Core\bin\debug\NBi.Testing.Core.dll NBi.Testing.Framework\bin\debug\NBi.Testing.Framework.dll NBi.Testing.GenbiL\bin\debug\NBi.Testing.GenbiL.dll NBi.Testing.Xml\bin\debug\NBi.Testing.Xml.dll  --where "cat!=Acceptance and cat!=Olap and cat!=Etl and cat!=WindowsService and cat!=ReportServerDB and cat!=LocalSQL" --result=myresults.xml;format=AppVeyor
     nunit-console-x86 NBi.Testing\bin\debug\NBi.Testing.dll /exclude:Olap,Etl,WindowsService,ReportServerDB,LocalSQL
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,8 @@ after_build:
 
     .\.packages\package-NBi.ps1 $nuget_version
 test_script:
+- cmd: setx NBiTestingUser "the_value_user"
+- cmd: RefreshEnv.cmd
 - cmd: >-
     nunit3-console NBi.Testing.Core\bin\debug\NBi.Testing.Core.dll NBi.Testing.Framework\bin\debug\NBi.Testing.Framework.dll NBi.Testing.GenbiL\bin\debug\NBi.Testing.GenbiL.dll NBi.Testing.Xml\bin\debug\NBi.Testing.Xml.dll  --where "cat!=Acceptance and cat!=Olap and cat!=Etl and cat!=WindowsService and cat!=ReportServerDB and cat!=LocalSQL" --result=myresults.xml;format=AppVeyor
     

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,13 +20,11 @@ after_build:
 
     .\.packages\package-NBi.ps1 $nuget_version
 test_script:
-- cmd: >-
+- cmd: |-
     setx NBiTestingUser "the_valueUser"
-    
     nunit3-console NBi.Testing.Core\bin\debug\NBi.Testing.Core.dll NBi.Testing.Framework\bin\debug\NBi.Testing.Framework.dll NBi.Testing.GenbiL\bin\debug\NBi.Testing.GenbiL.dll NBi.Testing.Xml\bin\debug\NBi.Testing.Xml.dll  --where "cat!=Acceptance and cat!=Olap and cat!=Etl and cat!=WindowsService and cat!=ReportServerDB and cat!=LocalSQL" --result=myresults.xml;format=AppVeyor
-    
     nunit-console-x86 NBi.Testing\bin\debug\NBi.Testing.dll /exclude:Olap,Etl,WindowsService,ReportServerDB,LocalSQL
-    
+
 artifacts:
 - path: NBi.NUnit.Runtime\bin\Debug
   name: Framework

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ after_build:
     .\.packages\package-NBi.ps1 $nuget_version
 test_script:
 - cmd: >-
+    setx NBiTestingUser "the_valueUser"
     nunit3-console NBi.Testing.Core\bin\debug\NBi.Testing.Core.dll NBi.Testing.Framework\bin\debug\NBi.Testing.Framework.dll NBi.Testing.GenbiL\bin\debug\NBi.Testing.GenbiL.dll NBi.Testing.Xml\bin\debug\NBi.Testing.Xml.dll  --where "cat!=Acceptance and cat!=Olap and cat!=Etl and cat!=WindowsService and cat!=ReportServerDB and cat!=LocalSQL" --result=myresults.xml;format=AppVeyor
     
     nunit-console-x86 NBi.Testing\bin\debug\NBi.Testing.dll /exclude:Olap,Etl,WindowsService,ReportServerDB,LocalSQL


### PR DESCRIPTION
Adjust to expected behavior and easier use in build systems.

Documentation of the different scopes of environment variables is at https://learn.microsoft.com/en-us/dotnet/api/system.environment.getenvironmentvariable?view=net-7.0#system-environment-getenvironmentvariable(system-string) .

Solves #717 

I have not tested this myself as I have no corresponding build environment, but this should solve it ...