### PR TITLE
chore: bump DubUrl from 0.18.51 to 0.20.38

### DIFF
--- a/NBi.Core/NBi.Core.csproj
+++ b/NBi.Core/NBi.Core.csproj
@@ -13,10 +13,10 @@
     <PackageReference Include="Azure.Identity" Version="1.12.0" /> 
     <PackageReference Include="Deedle" Version="3.0.0" />
     <PackageReference Include="Domemtech.StringTemplate4" Version="4.3.0" />
-    <PackageReference Include="DubUrl" Version="0.18.51" />
-    <PackageReference Include="DubUrl.Adomd" Version="0.18.51" />
-    <PackageReference Include="DubUrl.Extensions" Version="0.18.51" />
-    <PackageReference Include="DubUrl.OleDb" Version="0.18.51" />
+    <PackageReference Include="DubUrl" Version="0.20.38" />
+    <PackageReference Include="DubUrl.Adomd" Version="0.20.38" />
+    <PackageReference Include="DubUrl.Extensions" Version="0.20.38" />
+    <PackageReference Include="DubUrl.OleDb" Version="0.20.38" />
     <PackageReference Include="FSharp.Core" Version="8.0.101" />
     <PackageReference Include="FuzzyString.NETStandard" Version="1.0.0" />
     <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64" Version="19.84.1" /><PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" /> 
@@ -26,9 +26,9 @@
     <PackageReference Include="Ninject" Version="3.3.6" />
     <PackageReference Include="PocketCsvReader" Version="2.0.0" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
-    <PackageReference Include="System.Data.Odbc" Version="8.0.0" />
-    <PackageReference Include="System.Data.OleDb" Version="8.0.0" />
-    <PackageReference Include="System.Management" Version="8.0.0" />
+    <PackageReference Include="System.Data.Odbc" Version="9.0.2" />
+    <PackageReference Include="System.Data.OleDb" Version="9.0.2" />
+    <PackageReference Include="System.Management" Version="9.0.2" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
- bump System.Data.Odbc from 8.0.0 to 9.0.2
- bump System.Data.OleDb from 8.0.0 to 9.0.2
- bump System.Data.Management from 8.0.0 to 9.0.2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated external dependency versions to benefit from the latest enhancements and performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->