### PR TITLE
chore: bump Expressif from 1.9.0 to 1.10.11

### DIFF
--- a/NBi.Core/NBi.Core.csproj
+++ b/NBi.Core/NBi.Core.csproj
@@ -13,10 +13,10 @@
     <PackageReference Include="Azure.Identity" Version="1.12.0" /> 
     <PackageReference Include="Deedle" Version="3.0.0" />
     <PackageReference Include="Domemtech.StringTemplate4" Version="4.3.0" />
-    <PackageReference Include="DubUrl" Version="0.18.51" />
-    <PackageReference Include="DubUrl.Adomd" Version="0.18.51" />
-    <PackageReference Include="DubUrl.Extensions" Version="0.18.51" />
-    <PackageReference Include="DubUrl.OleDb" Version="0.18.51" />
+    <PackageReference Include="DubUrl" Version="0.20.38" />
+    <PackageReference Include="DubUrl.Adomd" Version="0.20.38" />
+    <PackageReference Include="DubUrl.Extensions" Version="0.20.38" />
+    <PackageReference Include="DubUrl.OleDb" Version="0.20.38" />
     <PackageReference Include="FSharp.Core" Version="8.0.101" />
     <PackageReference Include="FuzzyString.NETStandard" Version="1.0.0" />
     <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64" Version="19.84.1" /><PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" /> 
@@ -26,9 +26,9 @@
     <PackageReference Include="Ninject" Version="3.3.6" />
     <PackageReference Include="PocketCsvReader" Version="2.0.0" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
-    <PackageReference Include="System.Data.Odbc" Version="8.0.0" />
-    <PackageReference Include="System.Data.OleDb" Version="8.0.0" />
-    <PackageReference Include="System.Management" Version="8.0.0" />
+    <PackageReference Include="System.Data.Odbc" Version="9.0.2" />
+    <PackageReference Include="System.Data.OleDb" Version="9.0.2" />
+    <PackageReference Include="System.Management" Version="9.0.2" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/NBi.Extensibility/NBi.Extensibility.csproj
+++ b/NBi.Extensibility/NBi.Extensibility.csproj
@@ -1,7 +1,7 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Expressif" Version="1.9.0" />
+    <PackageReference Include="Expressif" Version="1.10.11" />
     <PackageReference Include="System.ValueTuple" version="4.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Upgraded key external dependencies to their latest versions, which may boost overall stability and performance.
- **Style**
	- Refined configuration formatting for cleaner and more consistent file structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->