### PR TITLE
chore: bump Moq from 4.20.70 to 4.20.72

### DIFF
--- a/NBi.Testing.Core/NBi.Core.Testing.csproj
+++ b/NBi.Testing.Core/NBi.Core.Testing.csproj
@@ -6,7 +6,7 @@
     <!--<PackageReference Include="NUnit.Analyzers" Version="3.10.0" />-->
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NBi.Core\NBi.Core.csproj" />

--- a/NBi.Testing.Framework/NBi.Framework.Testing.csproj
+++ b/NBi.Testing.Framework/NBi.Framework.Testing.csproj
@@ -6,7 +6,7 @@
     <!--<PackageReference Include="NUnit.Analyzers" Version="3.10.0" />-->
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NBi.Core\NBi.Core.csproj" />

--- a/NBi.Testing.GenbiL/NBi.GenbiL.Testing.csproj
+++ b/NBi.Testing.GenbiL/NBi.GenbiL.Testing.csproj
@@ -11,7 +11,7 @@
     <!--<PackageReference Include="NUnit.Analyzers" Version="3.10.0" />-->
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Templating\Resources\OrderedFull.nbitt" />

--- a/NBi.Testing.Xml/NBi.Xml.Testing.csproj
+++ b/NBi.Testing.Xml/NBi.Xml.Testing.csproj
@@ -11,7 +11,7 @@
     <!--<PackageReference Include="NUnit.Analyzers" Version="3.10.0" />-->
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
-    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Moq" Version="4.20.72" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\QueryFileEuro.mdx" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Moq dependency to version 4.20.72 across testing components for enhanced stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->