### PR TITLE
chore: bump Microsoft.Data.SqlClient from 5.1.4 to 6.0.1

### DIFF
--- a/NBi.Core/NBi.Core.csproj
+++ b/NBi.Core/NBi.Core.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="FuzzyString.NETStandard" Version="1.0.0" />
     <PackageReference Include="Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64" Version="19.84.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.8.0" /> 
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" /> 
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="6.0.1" /> 
     <PackageReference Include="NCalcSync" Version="5.4.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Ninject" Version="3.3.6" />


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Upgraded the SQL connectivity component to a newer version, delivering enhanced stability, performance, and potential bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->