### PR TITLE
chore: bump System.Management from 9.0.2 to 9.0.3

### DIFF
--- a/NBi.Core/NBi.Core.csproj
+++ b/NBi.Core/NBi.Core.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="System.Data.Odbc" Version="9.0.3" />
     <PackageReference Include="System.Data.OleDb" Version="9.0.3" />
-    <PackageReference Include="System.Management" Version="9.0.2" />
+    <PackageReference Include="System.Management" Version="9.0.3" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
chore: bump System.Management from 9.0.2 to 9.0.3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated a key system dependency to its latest version for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->