### PR TITLE
chore: bump PocketCsvReader from 2.27.8 to 2.35.4

### DIFF
--- a/NBi.Core/FlatFile/CsvProfile.cs
+++ b/NBi.Core/FlatFile/CsvProfile.cs
@@ -28,7 +28,7 @@ public class CsvProfile : PocketCsvReader.CsvProfile, IFlatFileProfile
                 { "record-separator", Dialect.LineTerminator },
                 { "first-row-header", Dialect.Header },
                 { "performance-optimized", !ParserOptimizations.RowCountAtStart },
-                { "missing-cell", base.MissingCell },
+                { "missing-cell", Dialect.MissingCell ?? "(null)" },
                 { "empty-cell", base.EmptyCell },
             };
 

--- a/NBi.Core/NBi.Core.csproj
+++ b/NBi.Core/NBi.Core.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="NCalcSync" Version="5.4.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Ninject" Version="3.3.6" />
-    <PackageReference Include="PocketCsvReader" Version="2.27.8" />
+    <PackageReference Include="PocketCsvReader" Version="2.35.4" />
     <PackageReference Include="RestSharp" Version="106.15.0" />
     <PackageReference Include="System.Data.Odbc" Version="9.0.3" />
     <PackageReference Include="System.Data.OleDb" Version="9.0.3" />

--- a/NBi.genbiL/NBi.genbiL.csproj
+++ b/NBi.genbiL/NBi.genbiL.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Domemtech.StringTemplate4" Version="4.3.0" />
-    <PackageReference Include="PocketCsvReader" Version="2.27.8" />
+    <PackageReference Include="PocketCsvReader" Version="2.35.4" />
     <PackageReference Include="Sprache" Version="2.3.1.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing cell values in CSV files, ensuring more accurate display when data is absent.

- **Chores**
  - Updated the PocketCsvReader library to version 2.35.4 for enhanced compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->