### PR TITLE
chore: bump Expressif from 1.10.11 to 1.10.13

### DIFF
--- a/NBi.Extensibility/NBi.Extensibility.csproj
+++ b/NBi.Extensibility/NBi.Extensibility.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
-    <PackageReference Include="Expressif" Version="1.10.11" />
+    <PackageReference Include="Expressif" Version="1.10.13" />
     <PackageReference Include="System.ValueTuple" version="4.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Expressif package to version 1.10.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->